### PR TITLE
Add `Unwrap` function for errors and add new errors types

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,9 +1,54 @@
 package urlquery
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
 	"strconv"
 )
+
+func ParamNameFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var errKey ErrInvalidParamKey
+	if errors.As(err, &errKey) {
+		return errKey.key
+	}
+	var errValue ErrInvalidParamValue
+	if errors.As(err, &errValue) {
+		return errValue.key
+	}
+	return ""
+}
+
+type ErrInvalidParamKey struct {
+	key string
+	err error
+}
+
+func (e ErrInvalidParamKey) Error() string {
+	return fmt.Sprintf("failed to parse param key %q: %v", e.key, e.err)
+}
+
+func (e ErrInvalidParamKey) Unwrap() error {
+	return e.err
+}
+
+// An ErrInvalidParamValue includes name of the param being decoded.
+type ErrInvalidParamValue struct {
+	val string
+	key string
+	err error
+}
+
+func (e ErrInvalidParamValue) Error() string {
+	return fmt.Sprintf("failed to parse param value %q for key %q: %v", e.val, e.key, e.err)
+}
+
+func (e ErrInvalidParamValue) Unwrap() error {
+	return e.err
+}
 
 // An ErrUnhandledType is a customized error
 type ErrUnhandledType struct {
@@ -37,6 +82,10 @@ type ErrTranslated struct {
 
 func (e ErrTranslated) Error() string {
 	return "failed to translate:" + e.err.Error()
+}
+
+func (e ErrTranslated) Unwrap() error {
+	return e.err
 }
 
 // An ErrInvalidMapKeyType is a customized error

--- a/error_test.go
+++ b/error_test.go
@@ -3,6 +3,7 @@ package urlquery
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -10,6 +11,44 @@ func TestErrUnhandledType_Error(t *testing.T) {
 	err := ErrUnhandledType{typ: reflect.TypeOf("s")}
 	if err.Error() != "failed to unhandled type(string)" {
 		t.Error(err.Error())
+	}
+}
+
+func TestParamNameFromError(t *testing.T) {
+	testCases := []struct {
+		err       error
+		paramName string
+	}{{
+		err:       nil,
+		paramName: "",
+	}, {
+		err:       ErrInvalidParamKey{key: "foo"},
+		paramName: "foo",
+	}, {
+		err:       ErrInvalidParamValue{key: "foo", val: "bar"},
+		paramName: "foo",
+	}, {
+		err:       ErrInvalidUnmarshalError{},
+		paramName: "",
+	}}
+	for i, tc := range testCases {
+		if paramName := ParamNameFromError(tc.err); paramName != tc.paramName {
+			t.Errorf("testCases[%d]: expected param name %q, got %q", i, tc.paramName, paramName)
+		}
+	}
+}
+
+func TestErrInvalidParamKey(t *testing.T) {
+	err := ErrInvalidParamKey{key: "foo"}
+	if errStr := err.Error(); !strings.Contains(errStr, "foo") {
+		t.Error("expected invalid param error to contain name of param")
+	}
+}
+
+func TestErrInvalidParamValue(t *testing.T) {
+	err := ErrInvalidParamValue{key: "foo", val: "bar"}
+	if errStr := err.Error(); !strings.Contains(errStr, "foo") || !strings.Contains(errStr, "bar") {
+		t.Error("expected invalid param error to contain name of param and name of value")
 	}
 }
 


### PR DESCRIPTION
# Description
_Context_
Previously this library did not have the ability to report back the name of the param that failed to be encoded. This change makes a number of changes in order to address this.

_This Diff_
- Adds new error types for invalid parameter keys and values.
- Adds a new function `ParamNameFromError` to extract the parameter name from an error
- Wraps many error return sites with the new error types
- Fixes tests to use `errors.As` and `errors.Is` unwrapping instead of explicit type assertion

# Test Plan
Added unit tests for these functions
Test coverage is 99.5%

# Documentation
Will add documentation before submitting this stack.

