### PR TITLE
Upgrade go.mod to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/hetiansu5/urlquery
 
-go 1.11
+go 1.21


### PR DESCRIPTION
# Description
_Context_
Our current go version is 1.21. Bump this go mod file to 1.21

_This Diff_
- Bumps the go mod file to be 1.21

# Test Plan
Unit tests

# Documentation
N/A
