### PR TITLE
Fix very obvious bug with mutex usage.

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -30,7 +30,7 @@ func (t *tag) getName() string {
 func (t *tag) contains(option string) bool {
 	var mutex sync.Mutex
 	mutex.Lock()
-	mutex.Unlock()
+	defer mutex.Unlock()
 	for _, o := range t.options {
 		if o == option {
 			return true


### PR DESCRIPTION
# Description
_Context_
The go linter discovered a suspicious mutex unlock and pointed it out.

_This Diff_
- Defers a mutex unlock that was very obviously supposed to be defered.

# Test Plan
Not really sure how to test this easily, but the unit tests still function.

# Documentation
N/A
