### PR TITLE
Allow ability to decode new types.

### DIFF
--- a/valuedecoder.go
+++ b/valuedecoder.go
@@ -3,7 +3,32 @@ package urlquery
 import (
 	"reflect"
 	"strconv"
+	"time"
 )
+
+// ValueDecoder are things that can decode string into a particular type
+// The DecodesType function returns whether the value decoder can
+// handle a particular type.
+type ValueDecoder interface {
+	DecodesType(reflect.Type) bool
+	Decode(value string) (reflect.Value, error)
+}
+
+var builtinDecoders = []ValueDecoder{TimeDecoder{}}
+
+type TimeDecoder struct{}
+
+func (TimeDecoder) Decode(value string) (reflect.Value, error) {
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return reflect.Value{}, err
+	}
+	return reflect.ValueOf(t), nil
+}
+
+func (TimeDecoder) DecodesType(t reflect.Type) bool {
+	return reflect.TypeOf(time.Time{}).ConvertibleTo(t)
+}
 
 // A valueDecode is a converter from string to go basic structure
 type valueDecode func(string) (reflect.Value, error)


### PR DESCRIPTION
# Description
_Context_
Currently the library only allows you to replace the default decoder for an entire kind. For this library to be more useful, we need a way to decode custom types, not just have a custom decoder for a kind.

_This Diff_
- Adds a `RegisterValueDecoder` function to the parser
- Adds a new interface `ValueDecoder` that can be used with `RegisterValueDecoder` to supply custom value decoders
- Check whether a registered `ValueDecoder` can decode the value before moving to the default logic
- Add new function `canDecodeImmediately` which checks whether any of the registered or builtin `ValueDecoder`s can run
- Before visiting further struct fields, be sure to check `canDecodeImmediately` and if so, decode immediately
- When setting the return value, convert the value type if it does not match. This allows automatic decoding of time fields, for example.
- Adds a builtin decoder for the `time.Time` type.

# Test Plan
Tested with new time and time pointer fields.
Unit test coverage is 99.5%
`parser.go` - only line 145 is untested.

# Documentation
Will update `README.md` before submitting.
