### PR TITLE
Allow ability to decode types that implement Decodable.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -294,7 +294,7 @@ func (p *parser) canImmediatelyDecode(typ reflect.Type) bool {
 			return true
 		}
 	}
-	return false
+	return isDecodable(typ)
 }
 
 // parse text to specified-type value
@@ -310,6 +310,10 @@ func (p *parser) decode(typ reflect.Type, value string) (v reflect.Value, err er
 			if d.DecodesType(typ) {
 				return d.Decode(value)
 			}
+		}
+		// Next check for
+		if rv, err, ok := maybeDecodeableDecode(typ, value); ok {
+			return rv, err
 		}
 	}
 	decodeFunc := p.getDecodeFunc(typ.Kind())

--- a/valuedecoder.go
+++ b/valuedecoder.go
@@ -30,6 +30,67 @@ func (TimeDecoder) DecodesType(t reflect.Type) bool {
 	return reflect.TypeOf(time.Time{}).ConvertibleTo(t)
 }
 
+// Any type that implements Decodable will be automatically
+// decoded using the DecodeValue function
+type Decodable interface {
+	UnmarshalQueryParam(value string) error
+}
+
+func isDecodable(typ reflect.Type) bool {
+	var d *Decodable
+	if typ.Implements(reflect.TypeOf(d).Elem()) {
+		if typ.Kind() == reflect.Pointer {
+			// Apparently pointers to things that implement something also count
+			// as implementing the thing. Because we can only instantiate
+			// one type automatically, we will just wait until
+			// the parser instantiates the pointer and then we will parse.
+			// For example, if we have a type that's a map and it implements Decodable
+			// but we're parsing a *map[string]string then we will let the parser handle the pointer
+			return !typ.Elem().Implements(reflect.TypeOf(d).Elem())
+		} else if typ.Kind() == reflect.Map {
+			return true
+		}
+		return false
+	}
+	return reflect.PointerTo(typ).Implements(reflect.TypeOf(d).Elem())
+}
+
+// Decode any type T if either T or *T implements Decodable
+// Returns the decoded value, nil, and true if successful
+// Returns the empty reflect.Value, error from Parse(), and true if unsuccessful
+// Returns the empty reflect.Value, nil, and false if not decodable
+func maybeDecodeableDecode(typ reflect.Type, value string) (reflect.Value, error, bool) {
+	var d Decodable
+	var rv reflect.Value
+	var mustIndirect bool
+	if typ.Implements(reflect.TypeOf(&d).Elem()) {
+		// Almost always Parse is going to be a pointer receiver
+		// but it might also be a map
+		if typ.Kind() == reflect.Pointer {
+			rv = reflect.New(typ.Elem())
+		} else if typ.Kind() == reflect.Map {
+			rv = reflect.MakeMap(typ)
+		} else {
+			return reflect.Value{}, nil, false
+		}
+		d = rv.Interface().(Decodable)
+	} else if reflect.PointerTo(typ).Implements(reflect.TypeOf(&d).Elem()) {
+		// We also allow a pointer to the type to implement Decodable
+		rv = reflect.New(typ)
+		d = rv.Interface().(Decodable)
+		mustIndirect = true
+	} else {
+		return reflect.Value{}, nil, false
+	}
+	if err := d.UnmarshalQueryParam(value); err != nil {
+		return reflect.Value{}, ErrTranslated{err: err}, true
+	}
+	if mustIndirect {
+		return rv.Elem(), nil, true
+	}
+	return rv, nil, true
+}
+
 // A valueDecode is a converter from string to go basic structure
 type valueDecode func(string) (reflect.Value, error)
 


### PR DESCRIPTION
# Description
_Context_
Currently this library doesn't have an interface that a value can use to automatically decode itself (like `UnmarshalJSON` in `encoding/json` for instance). This PR adds the ability to decode types that implement `Decodable` allowing any type to implement `UnmarshalQueryParam` allowing for easy conversion.

_This Diff_
- Add a new interface `Decodable`
- Add function `isDecodable` to detect `Decodable` types using reflection
- Use the `isDecodable` function to immediately decode `Decodable` values in the `parse` function
- Add a `maybeDecodableDecode` function that calls `DecodeQueryParam` for a value of the passed in type.
- Call `maybeDecodableDecode` after all of the custom decoders have finished processing.

# Test Plan
Added unit tests for two new decodable types.
Unit test coverage is 99.6%
`parser.go` - only line 145 is untested.

# Documentation
Will update `README.md` before submitting.
