### PR TITLE
Add new `required` tag and functionality

### DIFF
--- a/error.go
+++ b/error.go
@@ -19,7 +19,22 @@ func ParamNameFromError(err error) string {
 	if errors.As(err, &errValue) {
 		return errValue.key
 	}
+	var errMissing ErrMissingRequiredParam
+	if errors.As(err, &errMissing) {
+		return errMissing.key
+	}
 	return ""
+}
+
+func IsMissingParamError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errMissing ErrMissingRequiredParam
+	if errors.As(err, &errMissing) {
+		return true
+	}
+	return false
 }
 
 type ErrInvalidParamKey struct {
@@ -33,6 +48,14 @@ func (e ErrInvalidParamKey) Error() string {
 
 func (e ErrInvalidParamKey) Unwrap() error {
 	return e.err
+}
+
+type ErrMissingRequiredParam struct {
+	key string
+}
+
+func (e ErrMissingRequiredParam) Error() string {
+	return fmt.Sprintf("missing required param %q", e.key)
 }
 
 // An ErrInvalidParamValue includes name of the param being decoded.

--- a/error_test.go
+++ b/error_test.go
@@ -14,6 +14,30 @@ func TestErrUnhandledType_Error(t *testing.T) {
 	}
 }
 
+func TestIsMissingParamError(t *testing.T) {
+	testCases := []struct {
+		err    error
+		result bool
+	}{{
+		err:    nil,
+		result: false,
+	}, {
+		err:    ErrInvalidParamKey{key: "foo"},
+		result: false,
+	}, {
+		err:    ErrInvalidParamValue{key: "foo", val: "bar"},
+		result: false,
+	}, {
+		err:    ErrMissingRequiredParam{key: "foo"},
+		result: true,
+	}}
+	for i, tc := range testCases {
+		if res := IsMissingParamError(tc.err); res != tc.result {
+			t.Errorf("testCases[%d]: unexpected IsMissingParamError for %v: expected %t, got %t", i, tc.err, tc.result, res)
+		}
+	}
+}
+
 func TestParamNameFromError(t *testing.T) {
 	testCases := []struct {
 		err       error
@@ -30,6 +54,9 @@ func TestParamNameFromError(t *testing.T) {
 	}, {
 		err:       ErrInvalidUnmarshalError{},
 		paramName: "",
+	}, {
+		err:       ErrMissingRequiredParam{key: "foo"},
+		paramName: "foo",
 	}}
 	for i, tc := range testCases {
 		if paramName := ParamNameFromError(tc.err); paramName != tc.paramName {
@@ -49,6 +76,13 @@ func TestErrInvalidParamValue(t *testing.T) {
 	err := ErrInvalidParamValue{key: "foo", val: "bar"}
 	if errStr := err.Error(); !strings.Contains(errStr, "foo") || !strings.Contains(errStr, "bar") {
 		t.Error("expected invalid param error to contain name of param and name of value")
+	}
+}
+
+func TestErrMissingRequiredParam(t *testing.T) {
+	err := ErrMissingRequiredParam{key: "foo"}
+	if errStr := err.Error(); !strings.Contains(errStr, "foo") {
+		t.Error("expected missing param to contain name of missing param")
 	}
 }
 


### PR DESCRIPTION
# Description
_Context_
Currently, there is no support for marking fields as required. This PR recognizes a new `required` tag, which causes an error to be generated if the specified field is not provided in the query params.

_This Diff_
- Adds a boolean value to each `parseX` function indicating whether the field was found in the params.
- Uses the `found` return parameter from the `parse` call in `parseForStruct` and presence  of the `required` tag on the struct field to decide whether to return a missing parameter error.
- Create an `IsMissingParameterError` that returns whether the error is a missing parameter error.
- Create a new `ErrMissingQueryParam` error that indicates which query param is missing.
- Recognize and return the `key` field from the `ErrMissingQueryParam` error.
- Add unit tests for required fields.

# Test Plan
Added new unit tests for required fields.
Unit test coverage is 99.6%
`parser.go` - only line 162 is untested.

# Documentation
Will update `README.md` with new functionality before submitting.

