### PR TITLE
Expand functionality of maps to be able to contain most things.

### DIFF
--- a/error.go
+++ b/error.go
@@ -23,7 +23,27 @@ func ParamNameFromError(err error) string {
 	if errors.As(err, &errMissing) {
 		return errMissing.key
 	}
+	var errKeyType ErrInvalidMapKeyType
+	if errors.As(err, &errKeyType) {
+		return errKeyType.key
+	}
+	var errValueType ErrInvalidMapValueType
+	if errors.As(err, &errValueType) {
+		return errValueType.key
+	}
 	return ""
+}
+
+func IsInvalidParamError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errKey ErrInvalidParamKey
+	if errors.As(err, &errKey) {
+		return true
+	}
+	var errValue ErrInvalidParamValue
+	return errors.As(err, &errValue)
 }
 
 func IsMissingParamError(err error) bool {
@@ -31,7 +51,23 @@ func IsMissingParamError(err error) bool {
 		return false
 	}
 	var errMissing ErrMissingRequiredParam
-	if errors.As(err, &errMissing) {
+	return errors.As(err, &errMissing)
+}
+
+func IsInvalidDestinationValueError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errKeyType ErrInvalidMapKeyType
+	if errors.As(err, &errKeyType) {
+		return true
+	}
+	var errValueType ErrInvalidMapValueType
+	if errors.As(err, &errValueType) {
+		return true
+	}
+	var errUnhandledType ErrUnhandledType
+	if errors.As(err, &errUnhandledType) {
 		return true
 	}
 	return false
@@ -113,18 +149,20 @@ func (e ErrTranslated) Unwrap() error {
 
 // An ErrInvalidMapKeyType is a customized error
 type ErrInvalidMapKeyType struct {
+	key string
 	typ reflect.Type
 }
 
 func (e ErrInvalidMapKeyType) Error() string {
-	return "failed to handle map key type(" + e.typ.String() + ")"
+	return fmt.Sprintf("failed to handle map key type(%s) for key %q", e.typ.String(), e.key)
 }
 
 // An ErrInvalidMapValueType is a customized error
 type ErrInvalidMapValueType struct {
+	key string
 	typ reflect.Type
 }
 
 func (e ErrInvalidMapValueType) Error() string {
-	return "failed to handle map value type(" + e.typ.String() + ")"
+	return fmt.Sprintf("failed to handle map value type(%s) for key %q", e.typ.String(), e.key)
 }

--- a/function.go
+++ b/function.go
@@ -34,8 +34,12 @@ func isAccessMapKeyType(kind reflect.Kind) bool {
 }
 
 // check if reflect.Kind of map's value is valid
-func isAccessMapValueType(kind reflect.Kind) bool {
-	return isAccessMapKeyType(kind)
+func isAccessMapValueType(typ reflect.Type) bool {
+	kind := typ.Kind()
+	if kind == reflect.Pointer {
+		kind = typ.Elem().Kind()
+	}
+	return isAccessMapKeyType(kind) || kind == reflect.Struct || kind == reflect.Map || kind == reflect.Slice || kind == reflect.Array
 }
 
 // students[0][id] -> students, [0][id]


### PR DESCRIPTION
# Description
_Context_
Currently, the library does not handle most map value types. It only handles scalar types like `int`s and `string`s. There are many more types that should be allowed as map values including `struct` types, `map` types, slice types, array types, `Decodable` types, types that can be translated by a `ValueDecoder`, and pointers to these types or the aformentioned scalar types.

_This Diff_
- Expands list of values that can be immediately decoded (by checking `canImmediatelyDecode`) to include types decodable with a `ValueDecoder` and types that implement the `Decoder` interface.
- Expands the list of values to include composite types structs, maps, slices, and arrays as well as pointers to these types or scalar types.
- Adds new code to the `parseMap` value creation section, which generates a value by using reflection pass in a pointer to the type that is set by `p.parse`. The pointer to the type makes the value settable and `p.parse` already automatically handles all of these types.
- Adds a bunch of new unit tests for these tyes.
- Adds `key` to `ErrInvalidMapKeyType` and `ErrInvalidMapValueType` to allow callers to determine the key of the param that has an issue.
- Adds `IsInvalidParamError` helper function to check for invalid inputs
- Adds `IsInvalidDestinationValueError` helper function to check for invalid destination values being passed in. This helps callers differentiate between code errors and errors from query params.

# Test Plan
Added multiple unit tests for checking map values.
Test coverage is 99.8%
`parser.go` coverage is 100%

# Documentation
Will update `README.md` before submitting.

