### PR TITLE
Allow name `_` in `query` tag to indicate nameless struct field

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -296,6 +296,8 @@ func (p *parser) parseForStruct(rv reflect.Value, parentNode string) (found bool
 		name := t.getName()
 		if name == "" {
 			name = ft.Name
+		} else if name == "_" {
+			name = ""
 		}
 
 		nodeName := p.genNextParentNode(parentNode, name)

--- a/parser_test.go
+++ b/parser_test.go
@@ -86,6 +86,11 @@ func (tem testEncodedMap) MarshalQueryParam() string {
 	return sb.String()
 }
 
+type testInnerParamStruct struct {
+	InnerParamString string         `query:"inner_param_string"`
+	InnerParamStruct testParseChild `query:"inner_param_struct"`
+}
+
 type testParseInfo struct {
 	Id               int
 	Name             string           `query:"name"`
@@ -112,6 +117,7 @@ type testParseInfo struct {
 	EncodedMapPtr    *testEncodedMap         `query:"tem_ptr"`
 	StrArray3        testStrArray3           `query:"strarr3"`
 	IgnoreDecoder    testIgnoreDecoder       `query:"ignore_decoder"`
+	InnerParam       testInnerParamStruct    `query:"_"`
 }
 
 type testReplacementTimeDecoder struct{}
@@ -181,7 +187,7 @@ func TestParser_Unmarshal_NestedStructure(t *testing.T) {
 		"&Params[120]=1&Params[121]=2&status=1&UintPtr=300&tags[]=1&tags[]=2&Int64=64&Uint=22&Uint32=5&Float32=1.3" +
 		"&Float64=5.64&Bool=0&inter=ss&time=2024-01-02T18:30:22Z&time_ptr=2024-01-03T11:00:01Z&also_time=2024-01-02T03:04:05Z" +
 		"&encoded_string=foo&encoded_string_ptr=bar&tem=" + tem.MarshalQueryParam() + "&tem_ptr=" + tem.MarshalQueryParam() +
-		"&strarr3=foo,bar,baz&ignore_decoder[0]=foo&ignore_decoder[2]=baz"
+		"&strarr3=foo,bar,baz&ignore_decoder[0]=foo&ignore_decoder[2]=baz&inner_param_string=abc&inner_param_struct[desc]=testDesc"
 	data = encodeSquareBracket(data)
 	v := &testParseInfo{}
 	err := Unmarshal([]byte(data), v)
@@ -274,6 +280,9 @@ func TestParser_Unmarshal_NestedStructure(t *testing.T) {
 	}
 	if len(v.IgnoreDecoder) != 3 || v.IgnoreDecoder[0] != "foo" || v.IgnoreDecoder[2] != "baz" {
 		t.Errorf("invalid parse of IgnoreDecoder: %+v", v.IgnoreDecoder)
+	}
+	if v.InnerParam.InnerParamString != "abc" || v.InnerParam.InnerParamStruct.Description != "testDesc" {
+		t.Errorf("invalid parse of InnerParam: %+v", v.InnerParam)
 	}
 }
 


### PR DESCRIPTION
# Description
_Context_
Currently, it is not possible to make a param nameless. This is useful if you want to set values on an inner struct but don't want to give a name to the parent struct. This can happen when an API has a particular interface where query params are set at the top level but the destination of these is best on an inner struct.

For instance, consider the following struct:
```
type TestingParams struct {
  UseTestOption1 *bool `query:"use_test_option_1"`
  UseTestOption2 *bool `query:"use_test_option_2"`
}

type EndpointQueryParams struct {
...
  TestingParams TestingParams 
...
}
```

Now the endpoint being called is expecting `use_test_option_1=true` as a query parameter to the endpoint, and we want to parse into a `*EndpointQueryParams`, so cannot actually nest `TestingParams` inside `EndpointQueryParams` because we need `TestingParams` to be nameless. Otherwise, we would have to specify the options as `TestingParams[use_test_option_1]=true`, which might be how we want some APIs to work, but doesn't work well if you have existing parameters like this. Nameless params solve this problem because now if you make the `TestingParams` field nameless, `use_test_option_1=true` will go directly into the `TestingParams` struct as desired.

There are downsides to having nameless struct fields. The main one is that it could add ambiguity and result in cases where query params are used multiple times for each. Possibly the interface should not allow multiple nameless struct fields or shouldn't allow nameless struct fields for certain types of params like maps. Or maybe some extra state in the parser should be tracking which params are used and make sure that each param is only consumed once.

_This Diff_
- Add check for `_` as a field name in the `query:` tag and if it used, keep the name of the field being checked as `""`.
- Add a test for a nameless struct field.

# Test Plan
Added unit tests to test nameless struct fields.
Test coverage is 99.8%
Test coverage of `parser.go` is 100%

# Documentation
Will update `README.md` before submitting.
