### PR TITLE
Add error check for ambiguous parse for param

### DIFF
--- a/error.go
+++ b/error.go
@@ -31,6 +31,10 @@ func ParamNameFromError(err error) string {
 	if errors.As(err, &errValueType) {
 		return errValueType.key
 	}
+	var errAmbiguous ErrAmbiguousParseForParam
+	if errors.As(err, &errAmbiguous) {
+		return errAmbiguous.key
+	}
 	return ""
 }
 
@@ -70,7 +74,8 @@ func IsInvalidDestinationValueError(err error) bool {
 	if errors.As(err, &errUnhandledType) {
 		return true
 	}
-	return false
+	var errAmbiguous ErrAmbiguousParseForParam
+	return errors.As(err, &errAmbiguous)
 }
 
 type ErrInvalidParamKey struct {
@@ -165,4 +170,12 @@ type ErrInvalidMapValueType struct {
 
 func (e ErrInvalidMapValueType) Error() string {
 	return fmt.Sprintf("failed to handle map value type(%s) for key %q", e.typ.String(), e.key)
+}
+
+type ErrAmbiguousParseForParam struct {
+	key string
+}
+
+func (e ErrAmbiguousParseForParam) Error() string {
+	return fmt.Sprintf("key %q maps to multiple fields in destination value", e.key)
 }

--- a/error_test.go
+++ b/error_test.go
@@ -87,6 +87,9 @@ func TestIsInvalidDestinationValueError(t *testing.T) {
 	}, {
 		err:    ErrUnhandledType{typ: reflect.TypeOf("")},
 		result: true,
+	}, {
+		err:    ErrAmbiguousParseForParam{key: "foo"},
+		result: true,
 	}}
 	for i, tc := range testCases {
 		if res := IsInvalidDestinationValueError(tc.err); res != tc.result {


### PR DESCRIPTION
# Description
_Context_
Currently, if two struct fields have the same field name as defined by the `query:` tag, there is no error. There are many cases where this could cause the param to be set in multiple places. This problem already existed, but nameless struct fields made it worse. If a param is consumed twice, it almost certainly should probably be an error, although maybe we should be able to toggle the error with an option.

_This Diff_
- Adds a new `ErrAmbiguousParseForParam`
- Changes the map value type of the param container from `string` to `struct{ val string consumed bool}` to track param consumption.
- Changes the `get` function to `consume` which does the look up but also only allows the lookup to happen a single time, otherwise an error is set.
- Return early any place where `consume` is called and produces an error.

# Test Plan
Added unit tests for ambiguous params.
Test coverage is 99.7%.
`parser.go` coverage is 100%.

# Documentation
Will update `README.md` before submitting.
